### PR TITLE
XMPP backend: Errbot can send cards and files

### DIFF
--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -297,7 +297,8 @@ class XMPPRoomOccupant(XMPPPerson, RoomOccupant):
 
 class XMPPConnection(object):
     def __init__(self, jid, password, feature=None, keepalive=None,
-                 ca_cert=None, server=None, use_ipv6=None, bot=None):
+                 ca_cert=None, server=None, use_ipv6=None, bot=None,
+                 ssl_version=None):
         if feature is None:
             feature = {}
         self._bot = bot

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -538,16 +538,16 @@ class XMPPBackend(ErrBot):
         """
         image_url = iq['http_upload_slot']['get']['url']
         log.debug('Image slot received:' + image_url)
-        if self.processing_card is None:
+        if self._processing_card is None:
             return image_url
         m = self.conn.client.Message()
-        m['to'] = str(self.processing_card.to)
-        m['type'] = 'chat' if self.processing_card.is_direct else 'groupchat'
+        m['to'] = str(self._processing_card.to)
+        m['type'] = 'chat' if self._processing_card.is_direct else 'groupchat'
         m['body'] = image_url
         m['oob']['url'] = image_url
         m.send()
 
-        self.processing_card = None
+        self._processing_card = None
 
     def send_card(self, card: Card):
         log.debug("send_card to %s", card.to)

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -584,12 +584,16 @@ class XMPPBackend(ErrBot):
             log.debug("Trigger shutdown")
             self.shutdown()
 
+    async def _xep0030_get_info(self, txtrep):
+        xep0030 = self.conn.client.plugin['xep_0030']
+        return await xep0030.get_info(jid=txtrep)
+
     @lru_cache(IDENTIFIERS_LRU)
     def build_identifier(self, txtrep):
         log.debug('build identifier for %s', txtrep)
         try:
-            xep0030 = self.conn.client.plugin['xep_0030']
-            info = xep0030.get_info(jid=txtrep)
+            info = asyncio.run_coroutine_threadsafe(
+                self._xep0030_get_info(txtrep), self._loop).result()
             disco_info = info['disco_info']
             if disco_info:  # Hipchat can return an empty response here.
                 for category, typ, _, name in disco_info['identities']:

--- a/errbot/backends/xmpp.py
+++ b/errbot/backends/xmpp.py
@@ -496,6 +496,11 @@ class XMPPBackend(ErrBot):
 
     def connected(self, data):
         """Callback for connection events"""
+        # Required to send images or files when using a callback message.
+        # When the bot wants to send a file to the server, it must use the same
+        # event loop as the callback caller.
+        self._loop = asyncio.get_running_loop()
+
         self.connect_callback()
 
     def disconnected(self, data):


### PR DESCRIPTION
Hi!
I created a new function on the XMPP backend to send a file through XEP-0363. Also, I added it to the `send_card()` to send the image attached to it.

It is required a slight modification on the slixmpp library to use the callback function when calling slixmpp's `upload_file()` (see line 530 on the right side). This modification is on my [xep-0363-callback-fix](https://github.com/cnngimenez/slixmpp/tree/xep-0363-callback-fix) branch. I sent a pull request to the slixmpp main repository with this fix because the callback parameter has already been written on the `upload_file()` but it was not used in its implementation.

Also, I found a problem regarding `build_identifier()`. When I wanted to use it on a bot, it failed because it was using a different event loop instead of the one created by the XMPPConnection initialization. So, I stored the proper event loop at the `XMPPBackend._loop` as soon as a message is received and before passing control to the errbot core to process it.

In conclusion: *You can make errbots plugins that can send cards and files (images, videos, etc.) through XMPP and you can see them as usual by using Conversations.*